### PR TITLE
Broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ management of applications running on Flynn via an HTTP API.
 Currently the only consumer of the API is
 [flynn-cli](https://github.com/flynn/flynn-cli).
 
-flynn-controller communicates with [sampi](https://github.com/flynn/sampi) and
+flynn-controller communicates with [sampi](https://github.com/mshamber/sampi) and
 [lorne](https://github.com/flynn/lorne) to get the current state and run jobs.


### PR DESCRIPTION
change [sampi](https://github.com/flynn/sampi) Broken link, into [sampi](https://github.com/mshamber/sampi)
