### PR TITLE
Render an empty JSON array when crud lists are empty

### DIFF
--- a/crud.go
+++ b/crud.go
@@ -72,6 +72,10 @@ func crud(resource string, example interface{}, repo Repository, r martini.Route
 			r.JSON(500, struct{}{})
 			return
 		}
+		// render an empty JSON array (rather than null) if list is nil
+		if list == nil {
+			list = []struct{}{}
+		}
 		r.JSON(200, list)
 	})
 


### PR DESCRIPTION
Currently crud list endpoints return `null` rather than `[]` for empty lists, which seems wrong (I do find it surprising that `List` returns nil).

The build is currently failing with `./crud.go:77: list declared and not used`, but it is clearly "used" on line 79.

Thoughts?
