### PR TITLE
Fix rendering empty crud lists

### DIFF
--- a/app.go
+++ b/app.go
@@ -142,7 +142,7 @@ func (r *AppRepo) List() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	var apps []*ct.App
+	apps := []*ct.App{}
 	for rows.Next() {
 		app, err := scanApp(rows)
 		if err != nil {

--- a/artifact.go
+++ b/artifact.go
@@ -61,7 +61,7 @@ func (r *ArtifactRepo) List() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	var artifacts []*ct.Artifact
+	artifacts := []*ct.Artifact{}
 	for rows.Next() {
 		artifact, err := scanArtifact(rows)
 		if err != nil {

--- a/crud.go
+++ b/crud.go
@@ -72,10 +72,6 @@ func crud(resource string, example interface{}, repo Repository, r martini.Route
 			r.JSON(500, struct{}{})
 			return
 		}
-		// render an empty JSON array (rather than null) if list is nil
-		if list == nil {
-			list = []struct{}{}
-		}
 		r.JSON(200, list)
 	})
 

--- a/formation.go
+++ b/formation.go
@@ -95,7 +95,7 @@ func (r *FormationRepo) List(appID string) ([]*ct.Formation, error) {
 	if err != nil {
 		return nil, err
 	}
-	var formations []*ct.Formation
+	formations := []*ct.Formation{}
 	for rows.Next() {
 		formation, err := scanFormation(rows)
 		if err != nil {

--- a/key.go
+++ b/key.go
@@ -66,7 +66,7 @@ func (r *KeyRepo) List() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	var keys []*ct.Key
+	keys := []*ct.Key{}
 	for rows.Next() {
 		key, err := scanKey(rows)
 		if err != nil {

--- a/provider.go
+++ b/provider.go
@@ -55,7 +55,7 @@ func (r *ProviderRepo) List() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	var providers []*ct.Provider
+	providers := []*ct.Provider{}
 	for rows.Next() {
 		provider, err := scanProvider(rows)
 		if err != nil {

--- a/release.go
+++ b/release.go
@@ -64,7 +64,7 @@ func (r *ReleaseRepo) List() (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	var releases []*ct.Release
+	releases := []*ct.Release{}
 	for rows.Next() {
 		release, err := scanRelease(rows)
 		if err != nil {


### PR DESCRIPTION
My previous fix for this (#4) did not work as the empty lists were not equal to `nil`, it was just that the json encoder was encoding the (unallocated?) lists as `null`.

I tried `if len(list) == 0` but because `list` is of type `interface{}` I got:

```
# github.com/flynn/flynn-controller
./crud.go:76: invalid argument list (type interface {}) for len
```

So instead I am explicitly allocating the lists (I think).

I did attempt to write a test for this but I was tying myself in knots, so I have verified it with curl:

```
vagrant@flynn:/vagrant/controller$ curl -k -u ":${KEY}" https://localhost/keys                                                                                   
[]
```
