### PR TITLE
Support undeleting keys

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -61,12 +61,14 @@ $$ LANGUAGE plpgsql`,
     FOR EACH ROW EXECUTE PROCEDURE notify_formation()`,
 
 		`CREATE TABLE keys (
-    key_id text PRIMARY KEY,
+    key_id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    fingerprint text NOT NULL,
     key text NOT NULL,
     comment text,
     created_at timestamptz NOT NULL DEFAULT now(),
     deleted_at timestamptz
 )`,
+		`CREATE UNIQUE INDEX ON keys (fingerprint) WHERE deleted_at IS NULL`,
 
 		`CREATE TABLE app_logs (
     app_id uuid NOT NULL REFERENCES apps (app_id),


### PR DESCRIPTION
Due to the fact that deleting a key doesn't actually delete it from the db (it just sets it's deleted_at time), re-adding a key which has been deleted currently causes a 500 error with a log message of:

```
duplicate key value violates unique constraint "keys_pkey"
```

I have updated the logic so that if the key being added is a deleted key, set it's deleted_at back to NULL.
