### PR TITLE
Scheduler tests v1

### DIFF
--- a/controller_test.go
+++ b/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/flynn/rpcplus"
 	"github.com/go-martini/martini"
 
+	tu "github.com/flynn/flynn-controller/testutils"
 	ct "github.com/flynn/flynn-controller/types"
 	"github.com/flynn/flynn-controller/utils"
 	_ "github.com/flynn/pq"
@@ -25,7 +26,7 @@ import (
 func Test(t *testing.T) { TestingT(t) }
 
 type S struct {
-	cc  *fakeCluster
+	cc  *tu.FakeCluster
 	srv *httptest.Server
 	m   *martini.Martini
 }
@@ -65,7 +66,7 @@ func (s *S) SetUpSuite(c *C) {
 	}
 	dbw := testDBWrapper{DB: db, dsn: dsn}
 
-	s.cc = newFakeCluster()
+	s.cc = tu.NewFakeCluster()
 	handler, m := appHandler(handlerConfig{db: dbw, cc: s.cc, sc: newFakeRouter(), key: "test"})
 	s.m = m
 	s.srv = httptest.NewServer(handler)

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -316,6 +316,10 @@ func (fs *Formations) Delete(f *Formation) {
 	fs.mtx.Unlock()
 }
 
+func (fs *Formations) Len() int {
+	return len(fs.formations)
+}
+
 func NewFormation(c *context, ef *ct.ExpandedFormation) *Formation {
 	return &Formation{
 		AppID:     ef.App.ID,

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/flynn/flynn-controller/client"
+	tu "github.com/flynn/flynn-controller/testutils"
+	ct "github.com/flynn/flynn-controller/types"
+	"github.com/flynn/flynn-host/types"
+	. "github.com/titanous/gocheck"
+)
+
+// Hook gocheck up to the "go test" runner
+func Test(t *testing.T) { TestingT(t) }
+
+type S struct{}
+
+var _ = Suite(&S{})
+
+type fakeControllerClient struct {
+	releases   map[string]*ct.Release
+	artifacts  map[string]*ct.Artifact
+	formations map[formationKey]*ct.Formation
+}
+
+func (c *fakeControllerClient) GetRelease(releaseID string) (*ct.Release, error) {
+	if release, ok := c.releases[releaseID]; ok {
+		return release, nil
+	}
+	return nil, controller.ErrNotFound
+}
+
+func (c *fakeControllerClient) GetArtifact(artifactID string) (*ct.Artifact, error) {
+	if artifact, ok := c.artifacts[artifactID]; ok {
+		return artifact, nil
+	}
+	return nil, controller.ErrNotFound
+}
+
+func (c *fakeControllerClient) GetFormation(appID, releaseID string) (*ct.Formation, error) {
+	if formation, ok := c.formations[formationKey{appID, releaseID}]; ok {
+		return formation, nil
+	}
+	return nil, controller.ErrNotFound
+}
+
+func (c *fakeControllerClient) StreamFormations(since *time.Time) (<-chan *ct.ExpandedFormation, *error) {
+	return make(chan *ct.ExpandedFormation), nil
+}
+
+func (s *S) TestSyncCluster(c *C) {
+	appID := "app0"
+	artifact := &ct.Artifact{ID: "artifact0"}
+	release := &ct.Release{ID: "release0", ArtifactID: artifact.ID}
+	processes := map[string]int{"web": 1}
+
+	cc := &fakeControllerClient{
+		releases:  map[string]*ct.Release{release.ID: release},
+		artifacts: map[string]*ct.Artifact{artifact.ID: artifact},
+		formations: map[formationKey]*ct.Formation{
+			formationKey{appID, release.ID}: {AppID: appID, ReleaseID: release.ID, Processes: processes},
+		},
+	}
+
+	cl := tu.NewFakeCluster()
+	cl.SetHosts(map[string]host.Host{"host0": {
+		ID: "host0",
+		Jobs: []*host.Job{
+			{ID: "job0", Attributes: map[string]string{"flynn-controller.app": appID, "flynn-controller.release": release.ID, "flynn-controller.type": "web"}},
+		},
+	}})
+
+	cx := newContext(cc, cl)
+	cx.syncCluster()
+
+	c.Assert(cx.formations.Len(), Equals, 1)
+	formation := cx.formations.Get(appID, release.ID)
+	c.Assert(formation.AppID, Equals, appID)
+	c.Assert(formation.Release, DeepEquals, release)
+	c.Assert(formation.Artifact, DeepEquals, artifact)
+	c.Assert(formation.Processes, DeepEquals, processes)
+}

--- a/testutils/fake_cluster.go
+++ b/testutils/fake_cluster.go
@@ -1,0 +1,53 @@
+package testutils
+
+import (
+	"errors"
+
+	"github.com/flynn/flynn-host/types"
+	"github.com/flynn/go-flynn/cluster"
+)
+
+func NewFakeCluster() *FakeCluster {
+	return &FakeCluster{hostClients: make(map[string]cluster.Host)}
+}
+
+type FakeCluster struct {
+	hosts       map[string]host.Host
+	hostClients map[string]cluster.Host
+}
+
+func (c *FakeCluster) ListHosts() (map[string]host.Host, error) {
+	return c.hosts, nil
+}
+
+func (c *FakeCluster) GetHost(id string) host.Host {
+	return c.hosts[id]
+}
+
+func (c *FakeCluster) DialHost(id string) (cluster.Host, error) {
+	client, ok := c.hostClients[id]
+	if !ok {
+		return nil, errors.New("FakeCluster: unknown host")
+	}
+	return client, nil
+}
+
+func (c *FakeCluster) AddJobs(req *host.AddJobsReq) (*host.AddJobsRes, error) {
+	for hostID, jobs := range req.HostJobs {
+		host, ok := c.hosts[hostID]
+		if !ok {
+			return nil, errors.New("FakeCluster: unknown host")
+		}
+		host.Jobs = append(host.Jobs, jobs...)
+		c.hosts[hostID] = host
+	}
+	return &host.AddJobsRes{State: c.hosts}, nil
+}
+
+func (c *FakeCluster) SetHosts(h map[string]host.Host) {
+	c.hosts = h
+}
+
+func (c *FakeCluster) SetHostClient(id string, h cluster.Host) {
+	c.hostClients[id] = h
+}


### PR DESCRIPTION
I have moved `fakeCluster` into a shared `testutils` package, and added a test for `syncCluster` which checks that the context includes the correct formations after a sync.
