### PR TITLE
Scheduler tests v2

### DIFF
--- a/jobs_test.go
+++ b/jobs_test.go
@@ -60,8 +60,8 @@ func (l *fakeLog) Write([]byte) (int, error) {
 
 func (s *S) TestKillJob(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "killjob"})
-	hc := tu.NewFakeHostClient()
 	hostID, jobID := utils.UUID(), utils.UUID()
+	hc := tu.NewFakeHostClient(hostID)
 	s.cc.SetHostClient(hostID, hc)
 
 	res, err := s.Delete("/apps/" + app.ID + "/jobs/" + hostID + "-" + jobID)
@@ -72,8 +72,8 @@ func (s *S) TestKillJob(c *C) {
 
 func (s *S) TestJobLog(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "joblog"})
-	hc := tu.NewFakeHostClient()
 	hostID, jobID := utils.UUID(), utils.UUID()
+	hc := tu.NewFakeHostClient(hostID)
 	hc.SetAttach(jobID, newFakeLog(strings.NewReader("foo")))
 	s.cc.SetHostClient(hostID, hc)
 
@@ -92,8 +92,8 @@ func (s *S) TestJobLog(c *C) {
 
 func (s *S) TestJobLogSSE(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "joblog-sse"})
-	hc := tu.NewFakeHostClient()
 	hostID, jobID := utils.UUID(), utils.UUID()
+	hc := tu.NewFakeHostClient(hostID)
 	logData, err := base64.StdEncoding.DecodeString("AQAAAAAAABNMaXN0ZW5pbmcgb24gNTUwMDcKAQAAAAAAAA1oZWxsbyBzdGRvdXQKAgAAAAAAAA1oZWxsbyBzdGRlcnIK")
 	c.Assert(err, IsNil)
 	hc.SetAttach(jobID, newFakeLog(bytes.NewReader(logData)))
@@ -168,9 +168,9 @@ func (s *S) TestRunJobDetached(c *C) {
 
 func (s *S) TestRunJobAttached(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "run-attached"})
-	hc := tu.NewFakeHostClient()
-
 	hostID := utils.UUID()
+	hc := tu.NewFakeHostClient(hostID)
+
 	done := make(chan struct{})
 	var jobID string
 	hc.SetAttachFunc("*", func(req *host.AttachReq, wait bool) (cluster.ReadWriteCloser, func() error, error) {

--- a/jobs_test.go
+++ b/jobs_test.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	tu "github.com/flynn/flynn-controller/testutils"
 	ct "github.com/flynn/flynn-controller/types"
 	"github.com/flynn/flynn-controller/utils"
 	"github.com/flynn/flynn-host/types"
@@ -43,51 +44,6 @@ func (s *S) TestJobList(c *C) {
 	c.Assert(actual, DeepEquals, expected)
 }
 
-func newFakeHostClient() *fakeHostClient {
-	return &fakeHostClient{
-		stopped: make(map[string]bool),
-		attach:  make(map[string]attachFunc),
-	}
-}
-
-type fakeHostClient struct {
-	stopped map[string]bool
-	attach  map[string]attachFunc
-}
-
-func (c *fakeHostClient) ListJobs() (map[string]host.ActiveJob, error)                 { return nil, nil }
-func (c *fakeHostClient) GetJob(id string) (*host.ActiveJob, error)                    { return nil, nil }
-func (c *fakeHostClient) StreamEvents(id string, ch chan<- *host.Event) cluster.Stream { return nil }
-func (c *fakeHostClient) Close() error                                                 { return nil }
-func (c *fakeHostClient) Attach(req *host.AttachReq, wait bool) (cluster.ReadWriteCloser, func() error, error) {
-	f, ok := c.attach[req.JobID]
-	if !ok {
-		f = c.attach["*"]
-	}
-	return f(req, wait)
-}
-
-func (c *fakeHostClient) StopJob(id string) error {
-	c.stopped[id] = true
-	return nil
-}
-
-func (c *fakeHostClient) isStopped(id string) bool {
-	return c.stopped[id]
-}
-
-func (c *fakeHostClient) setAttach(id string, rwc cluster.ReadWriteCloser) {
-	c.attach[id] = func(*host.AttachReq, bool) (cluster.ReadWriteCloser, func() error, error) {
-		return rwc, nil, nil
-	}
-}
-
-func (c *fakeHostClient) setAttachFunc(id string, f attachFunc) {
-	c.attach[id] = f
-}
-
-type attachFunc func(req *host.AttachReq, wait bool) (cluster.ReadWriteCloser, func() error, error)
-
 func newFakeLog(r io.Reader) *fakeLog {
 	return &fakeLog{r}
 }
@@ -104,21 +60,21 @@ func (l *fakeLog) Write([]byte) (int, error) {
 
 func (s *S) TestKillJob(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "killjob"})
-	hc := newFakeHostClient()
+	hc := tu.NewFakeHostClient()
 	hostID, jobID := utils.UUID(), utils.UUID()
 	s.cc.SetHostClient(hostID, hc)
 
 	res, err := s.Delete("/apps/" + app.ID + "/jobs/" + hostID + "-" + jobID)
 	c.Assert(err, IsNil)
 	c.Assert(res.StatusCode, Equals, 200)
-	c.Assert(hc.isStopped(jobID), Equals, true)
+	c.Assert(hc.IsStopped(jobID), Equals, true)
 }
 
 func (s *S) TestJobLog(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "joblog"})
-	hc := newFakeHostClient()
+	hc := tu.NewFakeHostClient()
 	hostID, jobID := utils.UUID(), utils.UUID()
-	hc.setAttach(jobID, newFakeLog(strings.NewReader("foo")))
+	hc.SetAttach(jobID, newFakeLog(strings.NewReader("foo")))
 	s.cc.SetHostClient(hostID, hc)
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/apps/%s/jobs/%s-%s/log", s.srv.URL, app.ID, hostID, jobID), nil)
@@ -136,11 +92,11 @@ func (s *S) TestJobLog(c *C) {
 
 func (s *S) TestJobLogSSE(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "joblog-sse"})
-	hc := newFakeHostClient()
+	hc := tu.NewFakeHostClient()
 	hostID, jobID := utils.UUID(), utils.UUID()
 	logData, err := base64.StdEncoding.DecodeString("AQAAAAAAABNMaXN0ZW5pbmcgb24gNTUwMDcKAQAAAAAAAA1oZWxsbyBzdGRvdXQKAgAAAAAAAA1oZWxsbyBzdGRlcnIK")
 	c.Assert(err, IsNil)
-	hc.setAttach(jobID, newFakeLog(bytes.NewReader(logData)))
+	hc.SetAttach(jobID, newFakeLog(bytes.NewReader(logData)))
 	s.cc.SetHostClient(hostID, hc)
 
 	req, err := http.NewRequest("GET", fmt.Sprintf("%s/apps/%s/jobs/%s-%s/log", s.srv.URL, app.ID, hostID, jobID), nil)
@@ -212,12 +168,12 @@ func (s *S) TestRunJobDetached(c *C) {
 
 func (s *S) TestRunJobAttached(c *C) {
 	app := s.createTestApp(c, &ct.App{Name: "run-attached"})
-	hc := newFakeHostClient()
+	hc := tu.NewFakeHostClient()
 
 	hostID := utils.UUID()
 	done := make(chan struct{})
 	var jobID string
-	hc.setAttachFunc("*", func(req *host.AttachReq, wait bool) (cluster.ReadWriteCloser, func() error, error) {
+	hc.SetAttachFunc("*", func(req *host.AttachReq, wait bool) (cluster.ReadWriteCloser, func() error, error) {
 		c.Assert(wait, Equals, true)
 		c.Assert(req.JobID, Not(Equals), "")
 		c.Assert(req, DeepEquals, &host.AttachReq{

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -22,6 +22,7 @@ type fakeControllerClient struct {
 	releases   map[string]*ct.Release
 	artifacts  map[string]*ct.Artifact
 	formations map[formationKey]*ct.Formation
+	stream     chan *ct.ExpandedFormation
 }
 
 func (c *fakeControllerClient) GetRelease(releaseID string) (*ct.Release, error) {
@@ -46,14 +47,40 @@ func (c *fakeControllerClient) GetFormation(appID, releaseID string) (*ct.Format
 }
 
 func (c *fakeControllerClient) StreamFormations(since *time.Time) (<-chan *ct.ExpandedFormation, *error) {
-	return make(chan *ct.ExpandedFormation), nil
+	return c.stream, nil
 }
 
-func (s *S) TestSyncCluster(c *C) {
-	appID := "app0"
-	artifact := &ct.Artifact{ID: "artifact0"}
-	release := &ct.Release{ID: "release0", ArtifactID: artifact.ID}
+type formationUpdate struct {
+	processes map[string]int
+}
+
+func (f *formationUpdate) jobCount() int {
+	var count int
+	for _, num := range f.processes {
+		count += num
+	}
+	return count
+}
+
+func waitForFormationEvent(events <-chan *FormationEvent, c *C) {
+	select {
+	case <-events:
+	case <-time.After(time.Second):
+		c.Fatal("timed out waiting for Formation event")
+	}
+}
+
+func (s *S) TestWatchFormations(c *C) {
+	// Create a fake cluster with an existing running formation
+	appID := "existing-app"
+	artifact := &ct.Artifact{ID: "existing-artifact"}
+	release := &ct.Release{
+		ID:         "existing-release",
+		ArtifactID: artifact.ID,
+		Processes:  map[string]ct.ProcessType{"web": ct.ProcessType{Cmd: []string{"start", "web"}}},
+	}
 	processes := map[string]int{"web": 1}
+	stream := make(chan *ct.ExpandedFormation)
 
 	cc := &fakeControllerClient{
 		releases:  map[string]*ct.Release{release.ID: release},
@@ -61,23 +88,82 @@ func (s *S) TestSyncCluster(c *C) {
 		formations: map[formationKey]*ct.Formation{
 			formationKey{appID, release.ID}: {AppID: appID, ReleaseID: release.ID, Processes: processes},
 		},
+		stream: stream,
+	}
+
+	hostID := "host0"
+	jobID := "existing-job"
+	existingJob := &host.Job{
+		ID: jobID,
+		Attributes: map[string]string{
+			"flynn-controller.app":     appID,
+			"flynn-controller.release": release.ID,
+			"flynn-controller.type":    "web",
+		},
 	}
 
 	cl := tu.NewFakeCluster()
-	cl.SetHosts(map[string]host.Host{"host0": {
-		ID: "host0",
-		Jobs: []*host.Job{
-			{ID: "job0", Attributes: map[string]string{"flynn-controller.app": appID, "flynn-controller.release": release.ID, "flynn-controller.type": "web"}},
-		},
-	}})
+	cl.SetHosts(map[string]host.Host{hostID: host.Host{ID: hostID, Jobs: []*host.Job{existingJob}}})
+	cl.SetHostClient(hostID, tu.NewFakeHostClient(hostID))
 
+	events := make(chan *FormationEvent)
 	cx := newContext(cc, cl)
-	cx.syncCluster()
+	go cx.watchFormations(events)
 
+	// Give the scheduler chance to sync with the cluster, then check it's in sync
+	waitForFormationEvent(events, c)
 	c.Assert(cx.formations.Len(), Equals, 1)
 	formation := cx.formations.Get(appID, release.ID)
 	c.Assert(formation.AppID, Equals, appID)
 	c.Assert(formation.Release, DeepEquals, release)
 	c.Assert(formation.Artifact, DeepEquals, artifact)
 	c.Assert(formation.Processes, DeepEquals, processes)
+	c.Assert(cx.jobs.Len(), Equals, 1)
+	job := cx.jobs.Get(hostID, jobID)
+	c.Assert(job.Type, Equals, "web")
+
+	f := &ct.ExpandedFormation{
+		App: &ct.App{ID: "app0"},
+		Release: &ct.Release{
+			ID:         "release0",
+			ArtifactID: "artifact0",
+			Processes: map[string]ct.ProcessType{
+				"web":    ct.ProcessType{Cmd: []string{"start", "web"}},
+				"worker": ct.ProcessType{Cmd: []string{"start", "worker"}},
+			},
+		},
+		Artifact: &ct.Artifact{ID: "artifact0", Type: "docker", URI: "docker://foo/bar"},
+	}
+
+	updates := []*formationUpdate{
+		&formationUpdate{processes: map[string]int{"web": 2}},
+		&formationUpdate{processes: map[string]int{"web": 3, "worker": 1}},
+		&formationUpdate{processes: map[string]int{"web": 1}},
+	}
+
+	for _, u := range updates {
+		f.Processes = u.processes
+		stream <- f
+		waitForFormationEvent(events, c)
+
+		c.Assert(cx.formations.Len(), Equals, 2)
+		formation = cx.formations.Get(f.App.ID, f.Release.ID)
+		c.Assert(formation.AppID, Equals, f.App.ID)
+		c.Assert(formation.Release, DeepEquals, f.Release)
+		c.Assert(formation.Artifact, DeepEquals, f.Artifact)
+		c.Assert(formation.Processes, DeepEquals, f.Processes)
+
+		c.Assert(cx.jobs.Len(), Equals, u.jobCount()+1)
+		host := cl.GetHost(hostID)
+		c.Assert(len(host.Jobs), Equals, u.jobCount()+1)
+
+		processes := make(map[string]int, len(u.processes))
+		for _, job := range host.Jobs {
+			jobType := job.Attributes["flynn-controller.type"]
+			processes[jobType]++
+		}
+		// Ignore the existing web job
+		processes["web"]--
+		c.Assert(processes, DeepEquals, u.processes)
+	}
 }

--- a/testutils/fake_cluster.go
+++ b/testutils/fake_cluster.go
@@ -44,10 +44,27 @@ func (c *FakeCluster) AddJobs(req *host.AddJobsReq) (*host.AddJobsRes, error) {
 	return &host.AddJobsRes{State: c.hosts}, nil
 }
 
+func (c *FakeCluster) RemoveJob(hostID, jobID string) error {
+	h, ok := c.hosts[hostID]
+	if !ok {
+		return errors.New("FakeCluster: unknown host")
+	}
+	jobs := make([]*host.Job, 0, len(h.Jobs))
+	for _, job := range h.Jobs {
+		if job.ID != jobID {
+			jobs = append(jobs, job)
+		}
+	}
+	h.Jobs = jobs
+	c.hosts[hostID] = h
+	return nil
+}
+
 func (c *FakeCluster) SetHosts(h map[string]host.Host) {
 	c.hosts = h
 }
 
 func (c *FakeCluster) SetHostClient(id string, h cluster.Host) {
+	h.(*FakeHostClient).cluster = c
 	c.hostClients[id] = h
 }

--- a/testutils/fake_host_client.go
+++ b/testutils/fake_host_client.go
@@ -1,0 +1,51 @@
+package testutils
+
+import (
+	"github.com/flynn/flynn-host/types"
+	"github.com/flynn/go-flynn/cluster"
+)
+
+func NewFakeHostClient() *FakeHostClient {
+	return &FakeHostClient{
+		stopped: make(map[string]bool),
+		attach:  make(map[string]attachFunc),
+	}
+}
+
+type FakeHostClient struct {
+	stopped map[string]bool
+	attach  map[string]attachFunc
+}
+
+func (c *FakeHostClient) ListJobs() (map[string]host.ActiveJob, error)                 { return nil, nil }
+func (c *FakeHostClient) GetJob(id string) (*host.ActiveJob, error)                    { return nil, nil }
+func (c *FakeHostClient) StreamEvents(id string, ch chan<- *host.Event) cluster.Stream { return nil }
+func (c *FakeHostClient) Close() error                                                 { return nil }
+func (c *FakeHostClient) Attach(req *host.AttachReq, wait bool) (cluster.ReadWriteCloser, func() error, error) {
+	f, ok := c.attach[req.JobID]
+	if !ok {
+		f = c.attach["*"]
+	}
+	return f(req, wait)
+}
+
+func (c *FakeHostClient) StopJob(id string) error {
+	c.stopped[id] = true
+	return nil
+}
+
+func (c *FakeHostClient) IsStopped(id string) bool {
+	return c.stopped[id]
+}
+
+func (c *FakeHostClient) SetAttach(id string, rwc cluster.ReadWriteCloser) {
+	c.attach[id] = func(*host.AttachReq, bool) (cluster.ReadWriteCloser, func() error, error) {
+		return rwc, nil, nil
+	}
+}
+
+func (c *FakeHostClient) SetAttachFunc(id string, f attachFunc) {
+	c.attach[id] = f
+}
+
+type attachFunc func(req *host.AttachReq, wait bool) (cluster.ReadWriteCloser, func() error, error)

--- a/testutils/fake_host_client.go
+++ b/testutils/fake_host_client.go
@@ -5,16 +5,19 @@ import (
 	"github.com/flynn/go-flynn/cluster"
 )
 
-func NewFakeHostClient() *FakeHostClient {
+func NewFakeHostClient(hostID string) *FakeHostClient {
 	return &FakeHostClient{
+		hostID:  hostID,
 		stopped: make(map[string]bool),
 		attach:  make(map[string]attachFunc),
 	}
 }
 
 type FakeHostClient struct {
+	hostID  string
 	stopped map[string]bool
 	attach  map[string]attachFunc
+	cluster *FakeCluster
 }
 
 func (c *FakeHostClient) ListJobs() (map[string]host.ActiveJob, error)                 { return nil, nil }
@@ -31,6 +34,7 @@ func (c *FakeHostClient) Attach(req *host.AttachReq, wait bool) (cluster.ReadWri
 
 func (c *FakeHostClient) StopJob(id string) error {
 	c.stopped[id] = true
+	c.cluster.RemoveJob(c.hostID, id)
 	return nil
 }
 


### PR DESCRIPTION
Because syncCluster is just called at the start of watchFormations, I have just renamed and expanded the single test to first check the cluster sync, then test streaming formation changes.

As you can see in the TODO at the end of the test, removing jobs is not reflected in the fakeCluster host.Jobs as there is no link between hosts and hostClients, so I have left that final check commented for now, thoughts welcome on that one.
