### PR TITLE
Only remove jobs from the scheduler once they actually stop

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -549,7 +549,6 @@ func (f *Formation) remove(n int, name string) {
 			// TODO: log/handle error
 		}
 		f.jobs.Remove(name, k.hostID, k.jobID)
-		f.c.jobs.Remove(k.hostID, k.jobID)
 		if i++; i == n {
 			break
 		}

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -197,7 +197,6 @@ func (s *S) TestWatchFormations(c *C) {
 		c.Assert(formation.Artifact, DeepEquals, f.Artifact)
 		c.Assert(formation.Processes, DeepEquals, f.Processes)
 
-		c.Assert(cx.jobs.Len(), Equals, u.jobCount()+1)
 		host := cl.GetHost(hostID)
 		c.Assert(len(host.Jobs), Equals, u.jobCount()+1)
 


### PR DESCRIPTION
Previously when scaling down a formation, the job would be removed from the scheduler's known jobs during the formation's rectify routine, which would mean once the job actually stops and a stop event is emitted, the scheduler doesn't recognize the job id (see [here](https://github.com/flynn/flynn-controller/blob/master/scheduler/main.go#L227)) and so does not change it's state in the controller.

With this change, the job is only removed from the known jobs once it has actually stopped (i.e. once a stop event has been received from the host).
