### PR TITLE
Flap detection

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -20,7 +20,7 @@
 		},
 		{
 			"ImportPath": "github.com/flynn/flynn-host/types",
-			"Rev": "aa072a4db1972783518e21760146411b1b4dcde9"
+			"Rev": "21bf5b53f8abfa10a56a7e0e011f83d41edc2efe"
 		},
 		{
 			"ImportPath": "github.com/flynn/go-crypto-ssh",

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -18,6 +18,9 @@ import (
 
 var backoffPeriod = 10 * time.Minute
 
+// Allow mocking time.AfterFunc in tests
+var timeAfterFunc = time.AfterFunc
+
 func main() {
 	grohl.AddContext("app", "controller-scheduler")
 	grohl.Log(grohl.Data{"at": "start"})
@@ -481,7 +484,7 @@ func (f *Formation) RestartJob(typ, hostID, jobID string) {
 		for i := 0; i < job.restarts-1; i++ {
 			duration *= 2
 		}
-		job.timer = time.AfterFunc(duration, func() {
+		job.timer = timeAfterFunc(duration, func() {
 			f.restart(job)
 		})
 	}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -218,6 +218,11 @@ func (c *context) watchHost(id string, events chan<- *host.Event) {
 
 	g := grohl.NewContext(grohl.Data{"fn": "watchHost", "host.id": id})
 
+	// Nil event to mark the start of watching a host
+	if events != nil {
+		events <- nil
+	}
+
 	h, err := c.DialHost(id)
 	if err != nil {
 		// TODO: log/handle error

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -153,7 +153,7 @@ func (c *context) syncCluster(events chan<- *host.Event) {
 	c.mtx.Unlock()
 
 	for f := range rectify {
-		go f.rectify()
+		go f.Rectify()
 	}
 }
 

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/technoweenie/grohl"
 )
 
+var backoffPeriod = 10 * time.Minute
+
 func main() {
 	grohl.AddContext("app", "controller-scheduler")
 	grohl.Log(grohl.Data{"at": "start"})
@@ -146,7 +148,7 @@ func (c *context) syncCluster(events chan<- *host.Event) {
 			gg.Log(grohl.Data{"at": "addJob"})
 			j := f.jobs.Add(jobType, h.ID, job.ID)
 			j.Formation = f
-			c.jobs.Add(h.ID, job.ID, j)
+			c.jobs.Add(j)
 			rectify[f] = struct{}{}
 		}
 	}
@@ -235,6 +237,7 @@ func (c *context) watchHost(id string, events chan<- *host.Event) {
 			j.State = "starting"
 		case "start":
 			j.State = "up"
+			job.startedAt = event.Job.StartedAt
 		case "stop":
 			j.State = "down"
 		case "error":
@@ -255,7 +258,7 @@ func (c *context) watchHost(id string, events chan<- *host.Event) {
 		c.jobs.Remove(id, event.JobID)
 		go func() {
 			c.mtx.RLock()
-			job.Formation.RemoveJob(job.Type, id, event.JobID)
+			job.Formation.RestartJob(job.Type, id, event.JobID)
 			c.mtx.RUnlock()
 			if events != nil {
 				events <- event
@@ -311,9 +314,9 @@ type jobMap struct {
 	mtx  sync.RWMutex
 }
 
-func (m *jobMap) Add(hostID, jobID string, job *Job) {
+func (m *jobMap) Add(job *Job) {
 	m.mtx.Lock()
-	m.jobs[jobKey{hostID, jobID}] = job
+	m.jobs[jobKey{job.HostID, job.ID}] = job
 	m.mtx.Unlock()
 }
 
@@ -392,8 +395,14 @@ func NewFormation(c *context, ef *ct.ExpandedFormation) *Formation {
 }
 
 type Job struct {
+	ID        string
+	HostID    string
 	Type      string
 	Formation *Formation
+
+	restarts  int
+	timer     *time.Timer
+	startedAt time.Time
 }
 
 type jobTypeMap map[string]map[jobKey]*Job
@@ -404,14 +413,14 @@ func (m jobTypeMap) Add(typ, host, id string) *Job {
 		jobs = make(map[jobKey]*Job)
 		m[typ] = jobs
 	}
-	job := &Job{Type: typ}
+	job := &Job{ID: id, HostID: host, Type: typ}
 	jobs[jobKey{host, id}] = job
 	return job
 }
 
-func (m jobTypeMap) Remove(typ, host, id string) {
-	if jobs, ok := m[typ]; ok {
-		delete(jobs, jobKey{host, id})
+func (m jobTypeMap) Remove(job *Job) {
+	if jobs, ok := m[job.Type]; ok {
+		delete(jobs, jobKey{job.HostID, job.ID})
 	}
 }
 
@@ -446,12 +455,36 @@ func (f *Formation) Rectify() {
 	f.rectify()
 }
 
-func (f *Formation) RemoveJob(typ, hostID, jobID string) {
+func (f *Formation) RestartJob(typ, hostID, jobID string) {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 
-	f.jobs.Remove(typ, hostID, jobID)
-	f.rectify()
+	job := f.jobs.Get(typ, hostID, jobID)
+	if job == nil {
+		return
+	}
+	// If it's a one off job, just remove it
+	if job.Type == "" {
+		f.jobs.Remove(job)
+		return
+	}
+	// If the job was started more than backoffPeriod ago, reset it's restart count
+	// so that it will be restarted straight away
+	if job.startedAt.Before(time.Now().Add(-backoffPeriod)) {
+		job.restarts = 0
+	}
+	if job.restarts == 0 {
+		f.restart(job)
+	} else {
+		// wait backoffPeriod * 2 ^ (restarts - 1) before restarting
+		duration := backoffPeriod
+		for i := 0; i < job.restarts-1; i++ {
+			duration *= 2
+		}
+		job.timer = time.AfterFunc(duration, func() {
+			f.restart(job)
+		})
+	}
 }
 
 func (f *Formation) rectify() {
@@ -459,8 +492,9 @@ func (f *Formation) rectify() {
 
 	// update job counts
 	for t, expected := range f.Processes {
-		diff := expected - len(f.jobs[t])
-		g.Log(grohl.Data{"at": "update", "type": t, "expected": expected, "actual": len(f.jobs[t]), "diff": diff})
+		actual := len(f.jobs[t])
+		diff := expected - actual
+		g.Log(grohl.Data{"at": "update", "type": t, "expected": expected, "actual": actual, "diff": diff})
 		if diff > 0 {
 			f.add(diff, t)
 		} else if diff < 0 {
@@ -489,45 +523,69 @@ func (f *Formation) add(n int, name string) {
 		// TODO: log/handle error
 	}
 	for i := 0; i < n; i++ {
-		config.ID = cluster.RandomJobID("")
-		hosts, err := f.c.ListHosts()
+		hostID, jobID, err := f.start(name, config)
 		if err != nil {
 			// TODO: log/handle error
 		}
-		if len(hosts) == 0 {
-			// TODO: log/handle error
-		}
-		hostCounts := make(map[string]int, len(hosts))
-		for _, h := range hosts {
-			hostCounts[h.ID] = 0
-			for _, job := range h.Jobs {
-				if f.jobType(job) != name {
-					continue
-				}
-				hostCounts[h.ID]++
-			}
-		}
-		sh := make(sortHosts, 0, len(hosts))
-		for id, count := range hostCounts {
-			sh = append(sh, sortHost{id, count})
-		}
-		sh.Sort()
+		g.Log(grohl.Data{"host.id": hostID, "job.id": jobID})
 
-		h := hosts[sh[0].ID]
-
-		g.Log(grohl.Data{"host.id": h.ID, "job.id": config.ID})
-
-		job := f.jobs.Add(name, h.ID, config.ID)
+		job := f.jobs.Add(name, hostID, jobID)
 		job.Formation = f
-		f.c.jobs.Add(h.ID, config.ID, job)
+		f.c.jobs.Add(job)
+	}
+}
 
-		_, err = f.c.AddJobs(&host.AddJobsReq{HostJobs: map[string][]*host.Job{h.ID: {config}}})
-		if err != nil {
-			f.jobs.Remove(name, h.ID, config.ID)
-			f.c.jobs.Remove(h.ID, config.ID)
-			// TODO: log/handle error
+func (f *Formation) restart(stoppedJob *Job) error {
+	g := grohl.NewContext(grohl.Data{"fn": "restart", "app.id": f.AppID, "release.id": f.Release.ID})
+	g.Log(grohl.Data{"old.host.id": stoppedJob.HostID, "old.job.id": stoppedJob.ID})
+
+	newHostID, newJobID, err := f.start(stoppedJob.Type, nil)
+	if err != nil {
+		return err
+	}
+	g.Log(grohl.Data{"new.host.id": newHostID, "new.job.id": newJobID})
+	f.jobs.Remove(stoppedJob)
+	newJob := f.jobs.Add(stoppedJob.Type, newHostID, newJobID)
+	newJob.Formation = f
+	newJob.restarts = stoppedJob.restarts + 1
+	f.c.jobs.Add(newJob)
+	return nil
+}
+
+func (f *Formation) start(typ string, config *host.Job) (hostID, jobID string, err error) {
+	if config == nil {
+		if config, err = f.jobConfig(typ); err != nil {
+			return "", "", err
 		}
 	}
+	config.ID = cluster.RandomJobID("")
+	hosts, err := f.c.ListHosts()
+	if err != nil {
+		return "", "", err
+	}
+	if len(hosts) == 0 {
+		// TODO: log/handle error
+	}
+	hostCounts := make(map[string]int, len(hosts))
+	for _, h := range hosts {
+		hostCounts[h.ID] = 0
+		for _, job := range h.Jobs {
+			if f.jobType(job) != typ {
+				continue
+			}
+			hostCounts[h.ID]++
+		}
+	}
+	sh := make(sortHosts, 0, len(hosts))
+	for id, count := range hostCounts {
+		sh = append(sh, sortHost{id, count})
+	}
+	sh.Sort()
+
+	h := hosts[sh[0].ID]
+
+	_, err = f.c.AddJobs(&host.AddJobsReq{HostJobs: map[string][]*host.Job{h.ID: {config}}})
+	return h.ID, config.ID, err
 }
 
 func (f *Formation) jobType(job *host.Job) string {
@@ -542,13 +600,13 @@ func (f *Formation) remove(n int, name string) {
 	g := grohl.NewContext(grohl.Data{"fn": "remove", "app.id": f.AppID, "release.id": f.Release.ID})
 
 	i := 0
-	for k := range f.jobs[name] {
-		g.Log(grohl.Data{"host.id": k.hostID, "job.id": k.jobID})
+	for _, job := range f.jobs[name] {
+		g.Log(grohl.Data{"host.id": job.HostID, "job.id": job.ID})
 		// TODO: robust host handling
-		if err := f.c.hosts.Get(k.hostID).StopJob(k.jobID); err != nil {
+		if err := f.c.hosts.Get(job.HostID).StopJob(job.ID); err != nil {
 			// TODO: log/handle error
 		}
-		f.jobs.Remove(name, k.hostID, k.jobID)
+		f.jobs.Remove(job)
 		if i++; i == n {
 			break
 		}

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -256,14 +256,14 @@ func (c *context) watchHost(id string, events chan<- *host.Event) {
 		g.Log(grohl.Data{"at": "remove", "job.id": event.JobID, "event": event.Event})
 
 		c.jobs.Remove(id, event.JobID)
-		go func() {
+		go func(event *host.Event) {
 			c.mtx.RLock()
 			job.Formation.RestartJob(job.Type, id, event.JobID)
 			c.mtx.RUnlock()
 			if events != nil {
 				events <- event
 			}
-		}()
+		}(event)
 	}
 	// TODO: check error/reconnect
 }

--- a/testutils/fake_cluster.go
+++ b/testutils/fake_cluster.go
@@ -3,7 +3,6 @@ package testutils
 import (
 	"errors"
 	"sync"
-	"time"
 
 	"github.com/flynn/flynn-host/types"
 	"github.com/flynn/go-flynn/cluster"
@@ -59,15 +58,7 @@ func (c *FakeCluster) AddJobs(req *host.AddJobsReq) (*host.AddJobsRes, error) {
 		}
 		if client, ok := c.hostClients[hostID]; ok {
 			for _, job := range jobs {
-				// Send the start event asynchronously after a short period of time
-				// to give the caller chance to finish processing previous events
-				// before it receives the start event (e.g. when restarting jobs,
-				// the scheduler needs to track the new hostID and jobID before it
-				// can deal with a start event for that job).
-				go func() {
-					time.Sleep(100 * time.Millisecond)
-					client.SendEvent("start", job.ID)
-				}()
+				client.SendEvent("start", job.ID)
 			}
 		}
 		host.Jobs = append(host.Jobs, jobs...)

--- a/testutils/fake_cluster.go
+++ b/testutils/fake_cluster.go
@@ -80,6 +80,7 @@ func (c *FakeCluster) RemoveJob(hostID, jobID string, errored bool) error {
 	c.mtx.Lock()
 	h, ok := c.hosts[hostID]
 	if !ok {
+		c.mtx.Unlock()
 		return errors.New("FakeCluster: unknown host")
 	}
 	jobs := make([]*host.Job, 0, len(h.Jobs))


### PR DESCRIPTION
This is an initial attempt at a restart back-off policy when jobs crash:
- If the job is new (i.e. was created by a new / updated formation) restart it immediately and increment its restart count
- If the job was started more than 10 minutes ago, reset its restart count to zero and restart it immediately
- If the job was started less than 10 minutes ago, wait 10 \* 2 ^ (restart count - 1) minutes before restarting it

I have not added a test for this, but I have tried it out manually by switching the `backoffPeriod` to 30 seconds, manually killing jobs and seeing they are rescheduled as expected, the results of which can be seen in the following gist:

https://gist.github.com/lmars/a54a791e1434a0a311a8

Things that need addressing:
- Job restarts are not visible in the controller, so whilst the scheduler knows that jobs are queued to be restarted in the future, the controller will report that not enough jobs are running for a given formation
- When scaling down a formation, queued jobs should be removed first by just stopping their timer
- There is no upper limit on restart attempts

This depends on https://github.com/flynn/flynn-host/pull/17
