### PR TITLE
Generate config per job in the scheduler

### DIFF
--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -526,12 +526,8 @@ func (f *Formation) rectify() {
 func (f *Formation) add(n int, name string) {
 	g := grohl.NewContext(grohl.Data{"fn": "add", "app.id": f.AppID, "release.id": f.Release.ID})
 
-	config, err := f.jobConfig(name)
-	if err != nil {
-		// TODO: log/handle error
-	}
 	for i := 0; i < n; i++ {
-		job, err := f.start(name, config)
+		job, err := f.start(name)
 		if err != nil {
 			// TODO: log/handle error
 			continue
@@ -546,7 +542,7 @@ func (f *Formation) restart(stoppedJob *Job) error {
 
 	f.jobs.Remove(stoppedJob)
 
-	newJob, err := f.start(stoppedJob.Type, nil)
+	newJob, err := f.start(stoppedJob.Type)
 	if err != nil {
 		return err
 	}
@@ -555,11 +551,10 @@ func (f *Formation) restart(stoppedJob *Job) error {
 	return nil
 }
 
-func (f *Formation) start(typ string, config *host.Job) (job *Job, err error) {
-	if config == nil {
-		if config, err = f.jobConfig(typ); err != nil {
-			return nil, err
-		}
+func (f *Formation) start(typ string) (job *Job, err error) {
+	config, err := f.jobConfig(typ)
+	if err != nil {
+		return nil, err
 	}
 	config.ID = cluster.RandomJobID("")
 


### PR DESCRIPTION
We were getting intermittent errors in the scheduler tests:

```
FAIL: scheduler_test.go:173: S.TestWatchFormations

scheduler_test.go:242:
    c.Assert(jobCount, Equals, u.jobCount()+1)
    ... obtained int = 3
    ... expected int = 2
```

The issue was that when multiple jobs of a given type were started as
part of a single formation update, they all got stored in the
FakeCluster as the same struct because they all used the same config,
so modifying config.ID when starting each job was affecting jobs already
added to the Fake Cluster.

This then meant that removing jobs would either not remove any jobs
because the given ID did not match the ID which all the jobs had (i.e.
the last ID which config.ID was set to), or it would remove all the jobs
because they all had the given ID.

Generating the config per job fixes this.
