### PR TITLE
Scheduler reconnects

### DIFF
--- a/app.go
+++ b/app.go
@@ -167,7 +167,7 @@ func (r *AppRepo) Remove(id string) error {
 		return err
 	}
 
-	_, err = tx.Exec("UPDATE formations SET deleted_at = now(), processes = NULL WHERE app_id = $1 AND deleted_at IS NULL", id)
+	_, err = tx.Exec("UPDATE formations SET deleted_at = now(), processes = NULL, updated_at = now() WHERE app_id = $1 AND deleted_at IS NULL", id)
 	if err != nil {
 		tx.Rollback()
 		return err

--- a/formation.go
+++ b/formation.go
@@ -108,7 +108,7 @@ func (r *FormationRepo) List(appID string) ([]*ct.Formation, error) {
 }
 
 func (r *FormationRepo) Remove(appID, releaseID string) error {
-	err := r.db.Exec("UPDATE formations SET deleted_at = now(), processes = NULL WHERE app_id = $1 AND release_id = $2", appID, releaseID)
+	err := r.db.Exec("UPDATE formations SET deleted_at = now(), processes = NULL, updated_at = now() WHERE app_id = $1 AND release_id = $2", appID, releaseID)
 	if err != nil {
 		return err
 	}

--- a/formation.go
+++ b/formation.go
@@ -119,7 +119,8 @@ func (r *FormationRepo) publish(appID, releaseID string) {
 	formation, err := r.Get(appID, releaseID)
 	if err == ErrNotFound {
 		// formation delete event
-		formation = &ct.Formation{AppID: appID, ReleaseID: releaseID}
+		updated_at := time.Now()
+		formation = &ct.Formation{AppID: appID, ReleaseID: releaseID, UpdatedAt: &updated_at}
 	} else if err != nil {
 		// TODO: log error
 		return
@@ -156,6 +157,7 @@ func (r *FormationRepo) expandFormation(formation *ct.Formation) (*ct.ExpandedFo
 		Release:   release.(*ct.Release),
 		Artifact:  artifact.(*ct.Artifact),
 		Processes: formation.Processes,
+		UpdatedAt: *formation.UpdatedAt,
 	}
 	return f, nil
 }

--- a/scheduler/main.go
+++ b/scheduler/main.go
@@ -211,8 +211,6 @@ func (c *context) watchFormations(events chan<- *FormationEvent) {
 		}
 		g.Log(grohl.Data{"at": "disconnect"})
 	}
-
-	// TODO: trigger cluster sync
 }
 
 func (c *context) watchHosts(events chan<- *host.Event) {

--- a/types/types.go
+++ b/types/types.go
@@ -11,6 +11,7 @@ type ExpandedFormation struct {
 	Release   *Release       `json:"release,omitempty"`
 	Artifact  *Artifact      `json:"artifact,omitempty"`
 	Processes map[string]int `json:"processes,omitempty"`
+	UpdatedAt time.Time      `json:"updated_at,omitempty"`
 }
 
 type App struct {


### PR DESCRIPTION
- Update the scheduler to reconnect to the controller if there is an error or if the channel closes, waiting 1 second if more than one connection attempt has been made since the last update
- Add `ExpandedFormation.UpdatedAt` so that the scheduler can ask for only the updates since the last formation it received an event for
- Make deleted formations appear to have no processes so that the scheduler will remove it's processes if necessary
